### PR TITLE
How to add an R Markdown template to a package

### DIFF
--- a/16-projects.Rmd
+++ b/16-projects.Rmd
@@ -265,6 +265,26 @@ Note that you need to change the vignette title in both the `title` field and th
 
 The vignette output format does not have to be HTML. It can also be PDF, so you can use `output: pdf_document`, too. Any other output formats that create HTML or PDF are also okay, such as `beamer_presentation` and `tufte::tufte_html`. However, currently R only recognizes HTML and PDF vignettes.
 
+## R package templates
+
+In section \@ref(package-vignette), you learned how to include an R Markdown document in a package as a vignette. This is an excellent way to demonstrate the functionality of your package. However, it is not the only way that RMarkdown documents can be included in an R package. You may also include editable R Markdown templates in your package.
+
+R Markdown templates are often included to help package users structure their document correctly. In fact, section \@ref(package-vignette) itself shows this feature in action. The "Package Vignette (HTML)" template is contained in the **rmarkdown** package and is easily accessible through the RStudio IDE. This template gives vignette authors a file to edit which already contains the appropriate YAML metadata for an R Markdown vignette. Templates can also help demonstrate package features and provide scaffolding code for users. For example, the **flexdashboard** package contains a sample dashboard template and the **xaringan** package contains a template demonstrating many formatting features. 
+
+Each R Markdown template lives in its own subdirectory of the `inst/rmarkdown/templates` directory of your package. Within this directory, you will create at least two files:
+
+1. A file named `template.yaml` which gives the RStudio IDE basic metadata such as a human-readable name for the template
+
+```yaml
+name: Example Template
+```
+
+2. An R Markdown document saved under `skeleton/skeleton.Rmd` which contains the template. This may contain anything you wish to put in an R Markdown document. 
+
+Optionally, the `skeleton` folder may also include additional resources like style sheets or images used by your template. 
+
+As with vignettes, the **usethis** package has the helpful function `usethis::use_rmarkdown_template()` which automatically creates the required subdirectories and files.
+
 ## Write books and long-form reports with **bookdown** {#bookdown}
 
 The **bookdown** package [@R-bookdown] is designed for creating long-form documents with multiple R Markdown documents. For example, if you want to write a book, you can put each chapter in its own Rmd file.

--- a/16-projects.Rmd
+++ b/16-projects.Rmd
@@ -281,7 +281,7 @@ Other templates demonstrate required document structure. For example, the **page
 
 Templates may also demonstrate package features and syntax. For example, the **flexdashboard** package and the **learnr** package both include templates with code chunks that call functions from the packages to create a sample dashboard or tutorial, respectively. 
 
-Similarly, templates may also include boilerplate content. For example, the **rticles** package provides many such templates to align R Markdown output to the required style and content guidelines of different academic journals. Boilerplate content is also useful in in organizational settings, such as a team generating a quarterly reports. One example of,    
+Similarly, templates may also include boilerplate content. For example, the **rticles** package provides many such templates to align R Markdown output to the required style and content guidelines of different academic journals. Boilerplate content is also useful in in organizational settings, such as a team generating a quarterly reports. 
 
 ### Template set-up
 

--- a/16-projects.Rmd
+++ b/16-projects.Rmd
@@ -267,25 +267,27 @@ The vignette output format does not have to be HTML. It can also be PDF, so you 
 
 ## R Markdown templates
 
-Figure \@ref(fig:package-vignette) of section \@ref(package-vignette) illustrates the process of retrieving the editable "Package Vignette (HTML)" template from the **rmarkdown** package. This R Markdown file opens pre-populated with the appropriate metadata for an R package vignette. 
+Figure \@ref(fig:package-vignette) of section \@ref(package-vignette) illustrates the process of retrieving the editable "Package Vignette (HTML)" template from the **rmarkdown** package. This R Markdown file is pre-populated with the appropriate metadata for an R package vignette. 
 
-Similarly, any package may include R Markdown templates for package users to access through the RStudio IDE (as shown in the figure) or across any platform with `rmarkdown::draft()` function.
+Similarly, any package may include R Markdown templates whcih package users can access through the RStudio IDE (as shown in the figure) or across any platform with the `rmarkdown::draft()` function.
 
 ### Template use-cases
 
-Templates are a useful way to share custom structure, style, and content.
+Templates are a useful way to share custom structure, style, and content. There are many excellent examples of this "in the wild".
 
-Many add structure and style by pre-populating the YAML metadata. We already saw this with the **rmarkdown** "Package Vignette (HTML)" template. Similarly, the **rmdformats** package provides a number of templates which pass different custom styling functions to the `output` option. 
+Many templates add structure and style by pre-populating the YAML metadata. We already saw an example of this with the **rmarkdown** package's "Package Vignette (HTML)" template. Similarly, the **rmdformats** package provides a number of templates which pass different custom styling functions to the `output` option. 
 
-Other templates can be used to demonstrate required document structure. For example, the **pagedown** package includes a multitude of templates for posters, resumes, and more. Similarly, the **xaringan** package's "Ninja Presentation" template demonstrates the syntax for many different slide formatting options. 
+Other templates demonstrate required document structure. For example, the **pagedown** package includes numerous templates for posters, resumes, and other page layouts Similarly, the **xaringan** package's "Ninja Presentation" template demonstrates the syntax for many different slide formatting options. 
 
-Templates may also demonstrate package functionality. For example, the **flexdashboard** package and the **learnr** package both include templates with code chunks that call a number of the package functions to create a sample dashboard or lesson, respectively. 
+Templates may also demonstrate package features and syntax. For example, the **flexdashboard** package and the **learnr** package both include templates with code chunks that call functions from the packages to create a sample dashboard or tutorial, respectively. 
 
-Finally, templates may also include boilerplate content. This is particularly useful in organizational settings, such as a team generating a quarterly reports. Similarly, the **rticles** package provides many such templates to align R Markdown output to the required style and content guidelines of different academic journals.   
+Similarly, templates may also include boilerplate content. For example, the **rticles** package provides many such templates to align R Markdown output to the required style and content guidelines of different academic journals. Boilerplate content is also useful in in organizational settings, such as a team generating a quarterly reports. One example of,    
 
 ### Template set-up
 
-To add an R Markdown template to a package, create a subdirectory of the `inst/rmarkdown/templates` directory. Within this directory, you will save at least two files:
+The **usethis** package has a helpful function for creating templates. Running `usethis::use_rmarkdown_template()` will automatically create the required directory structure and files.
+
+If instead you wish to set up your template manually, create a subdirectory of the `inst/rmarkdown/templates` directory. Within this directory, you will save at least two files:
 
 1. A file named `template.yaml` which gives the RStudio IDE basic metadata such as a human-readable name for the template. At minimum, this file should have `name` and `description` fields. 
 
@@ -294,13 +296,11 @@ name: Example Template
 description: What this template does
 ```
 
-You may include is `create_dir: true` if you want a new directory to be created when the template is selected. This is useful if your template relies upon additional resources. For example, the **learnr** [package template](https://github.com/rstudio/learnr/blob/master/inst/rmarkdown/templates/tutorial/template.yaml) sets `create_dir: true` whereas the **flexdashboard** [package template](https://github.com/rstudio/flexdashboard/blob/master/inst/rmarkdown/templates/flex_dashboard/template.yaml) uses the default `create_dir: false`. You may attempt to open both of these templates in RStudio to note the difference in user prompts.
+You may include is `create_dir: true` if you want a new directory to be created when the template is selected. This is useful if your template relies upon additional resources. For example, the **learnr** [package template](https://github.com/rstudio/learnr/blob/master/inst/rmarkdown/templates/tutorial/template.yaml) sets `create_dir: true` whereas the **flexdashboard** [package template](https://github.com/rstudio/flexdashboard/blob/master/inst/rmarkdown/templates/flex_dashboard/template.yaml) uses the default `create_dir: false`. You may attempt to open both of these templates in RStudio to notice the differet user prompts.
 
 2. An R Markdown document saved under `skeleton/skeleton.Rmd`. This may contain anything you wish to put in an R Markdown document. 
 
-Optionally, the `skeleton` folder may also include additional resources like style sheets or images used by your template. 
-
-Similar to vignettes, the **usethis** package also has a helpful function for creating templates. Running `usethis::use_rmarkdown_template()` will automatically create the required directory structure and files.
+Optionally, the `skeleton` folder may also include additional resources like style sheets or images used by your template. These files will be loaded to the user's computer along with the template.
 
 For more details on building custom R Markdown templates, please refer to the [RStudio Extensions](https://rstudio.github.io/rstudio-extensions/rmarkdown_templates.html) website and the [Document Templates chapter](https://bookdown.org/yihui/rmarkdown/document-templates.html) of the R Markdown Definitive Guide [@rmarkdown2018]. 
 

--- a/16-projects.Rmd
+++ b/16-projects.Rmd
@@ -265,27 +265,44 @@ Note that you need to change the vignette title in both the `title` field and th
 
 The vignette output format does not have to be HTML. It can also be PDF, so you can use `output: pdf_document`, too. Any other output formats that create HTML or PDF are also okay, such as `beamer_presentation` and `tufte::tufte_html`. However, currently R only recognizes HTML and PDF vignettes.
 
-## R package templates
+## R Markdown templates
 
-In section \@ref(package-vignette), you learned how to include an R Markdown document in a package as a vignette. This is an excellent way to demonstrate the package's functionality, but it is not the only way that R Markdown documents can be used in an R package. As a package developer, you may also include editable R Markdown templates in your package.
+Figure \@ref(fig:package-vignette) of section \@ref(package-vignette) illustrates the process of retrieving the editable "Package Vignette (HTML)" template from the **rmarkdown** package. This R Markdown file opens pre-populated with the appropriate metadata for an R package vignette. 
 
-R Markdown templates help package users interact with a package by providing boilerplate code or document structure. In fact, section \@ref(package-vignette) on package vignettes provides a compelling use case. Figure \@ref(fig:package-vignette) shows how RStudio users can use the menu `File -> New File -> R Markdown -> From Template` to retrieve the "Package Vignette (HTML)" template from the **rmarkdown** package. This template offers a file to edit which already contains the appropriate YAML metadata for a package vignette. 
+Similarly, any package may include R Markdown templates for package users to access through the RStudio IDE (as shown in the figure) or across any platform with `rmarkdown::draft()` function.
 
-Templates can also include boilerplate content and showcase a package's features. For example, the **flexdashboard** package contains a sample dashboard and the **xaringan** package contains a presentation template which demonstrates many formatting options.
+### Template use-cases
+
+Templates are a useful way to share custom structure, style, and content.
+
+Many add structure and style by pre-populating the YAML metadata. We already saw this with the **rmarkdown** "Package Vignette (HTML)" template. Similarly, the **rmdformats** package provides a number of templates which pass different custom styling functions to the `output` option. 
+
+Other templates can be used to demonstrate required document structure. For example, the **pagedown** package includes a multitude of templates for posters, resumes, and more. Similarly, the **xaringan** package's "Ninja Presentation" template demonstrates the syntax for many different slide formatting options. 
+
+Templates may also demonstrate package functionality. For example, the **flexdashboard** package and the **learnr** package both include templates with code chunks that call a number of the package functions to create a sample dashboard or lesson, respectively. 
+
+Finally, templates may also include boilerplate content. This is particularly useful in organizational settings, such as a team generating a quarterly reports. Similarly, the **rticles** package provides many such templates to align R Markdown output to the required style and content guidelines of different academic journals.   
+
+### Template set-up
 
 To add an R Markdown template to a package, create a subdirectory of the `inst/rmarkdown/templates` directory. Within this directory, you will save at least two files:
 
-1. A file named `template.yaml` which gives the RStudio IDE basic metadata such as a human-readable name for the template
+1. A file named `template.yaml` which gives the RStudio IDE basic metadata such as a human-readable name for the template. At minimum, this file should have `name` and `description` fields. 
 
 ```yaml
 name: Example Template
+description: What this template does
 ```
 
-2. An R Markdown document saved under `skeleton/skeleton.Rmd` which contains the template. This may contain anything you wish to put in an R Markdown document. 
+You may include is `create_dir: true` if you want a new directory to be created when the template is selected. This is useful if your template relies upon additional resources. For example, the **learnr** [package template](https://github.com/rstudio/learnr/blob/master/inst/rmarkdown/templates/tutorial/template.yaml) sets `create_dir: true` whereas the **flexdashboard** [package template](https://github.com/rstudio/flexdashboard/blob/master/inst/rmarkdown/templates/flex_dashboard/template.yaml) uses the default `create_dir: false`. You may attempt to open both of these templates in RStudio to note the difference in user prompts.
+
+2. An R Markdown document saved under `skeleton/skeleton.Rmd`. This may contain anything you wish to put in an R Markdown document. 
 
 Optionally, the `skeleton` folder may also include additional resources like style sheets or images used by your template. 
 
-Similar to vignettes, the **usethis** package also has a helpful function for creating templates. Running `usethis::use_rmarkdown_template()` will automatically create the required subdirectories and files.
+Similar to vignettes, the **usethis** package also has a helpful function for creating templates. Running `usethis::use_rmarkdown_template()` will automatically create the required directory structure and files.
+
+For more details on building custom R Markdown templates, please refer to the [RStudio Extensions](https://rstudio.github.io/rstudio-extensions/rmarkdown_templates.html) website and the [Document Templates chapter](https://bookdown.org/yihui/rmarkdown/document-templates.html) of the R Markdown Definitive Guide [@rmarkdown2018]. 
 
 ## Write books and long-form reports with **bookdown** {#bookdown}
 

--- a/16-projects.Rmd
+++ b/16-projects.Rmd
@@ -265,7 +265,7 @@ Note that you need to change the vignette title in both the `title` field and th
 
 The vignette output format does not have to be HTML. It can also be PDF, so you can use `output: pdf_document`, too. Any other output formats that create HTML or PDF are also okay, such as `beamer_presentation` and `tufte::tufte_html`. However, currently R only recognizes HTML and PDF vignettes.
 
-## R Markdown templates
+## R Markdown templates in R packages {#package-template}
 
 Figure \@ref(fig:package-vignette) of section \@ref(package-vignette) illustrates the process of retrieving the editable "Package Vignette (HTML)" template from the **rmarkdown** package. This R Markdown file is pre-populated with the appropriate metadata for an R package vignette. 
 

--- a/16-projects.Rmd
+++ b/16-projects.Rmd
@@ -267,36 +267,35 @@ The vignette output format does not have to be HTML. It can also be PDF, so you 
 
 ## R Markdown templates in R packages {#package-template}
 
-Figure \@ref(fig:package-vignette) of section \@ref(package-vignette) illustrates the process of retrieving the editable "Package Vignette (HTML)" template from the **rmarkdown** package. This R Markdown file is pre-populated with the appropriate metadata for an R package vignette. 
-
-Similarly, any package may include R Markdown templates whcih package users can access through the RStudio IDE (as shown in the figure) or across any platform with the `rmarkdown::draft()` function.
+Figure \@ref(fig:package-vignette) of Section \@ref(package-vignette) illustrates the process of retrieving the editable "Package Vignette (HTML)" template from the **rmarkdown** package. This R Markdown file is pre-populated with the appropriate metadata for an R package vignette. 
+Similarly, any package may include R Markdown templates that package users can access through the RStudio IDE (as shown in the figure) or across any platform with the `rmarkdown::draft()` function.
 
 ### Template use-cases
 
 Templates are a useful way to share custom structure, style, and content. There are many excellent examples of this "in the wild".
 
-Many templates add structure and style by pre-populating the YAML metadata. We already saw an example of this with the **rmarkdown** package's "Package Vignette (HTML)" template. Similarly, the **rmdformats** package provides a number of templates which pass different custom styling functions to the `output` option. 
+Many templates add structure and style by pre-populating the YAML metadata. We already saw an example of this with the **rmarkdown** package's "Package Vignette (HTML)" template. Similarly, the **rmdformats** package provides a number of templates that pass different custom styling functions to the `output` option.
 
-Other templates demonstrate required document structure. For example, the **pagedown** package includes numerous templates for posters, resumes, and other page layouts Similarly, the **xaringan** package's "Ninja Presentation" template demonstrates the syntax for many different slide formatting options. 
+Other templates demonstrate required document structures by the packages. For example, the **pagedown** package includes numerous templates for posters, resumes, and other page layouts. Similarly, the **xaringan** package's "Ninja Presentation" template demonstrates the syntax for many different slide formatting options. 
 
-Templates may also demonstrate package features and syntax. For example, the **flexdashboard** package and the **learnr** package both include templates with code chunks that call functions from the packages to create a sample dashboard or tutorial, respectively. 
+Templates may also demonstrate package features and syntax. For example, both the **flexdashboard** package and the **learnr** package include templates with code chunks that call functions from the packages to create a sample dashboard or tutorial, respectively.
 
 Similarly, templates may also include boilerplate content. For example, the **rticles** package provides many such templates to align R Markdown output to the required style and content guidelines of different academic journals. Boilerplate content is also useful in in organizational settings, such as a team generating a quarterly reports. 
 
 ### Template set-up
 
-The **usethis** package has a helpful function for creating templates. Running `usethis::use_rmarkdown_template()` will automatically create the required directory structure and files.
+The **usethis** package has a helpful function for creating templates. Running `usethis::use_rmarkdown_template("Template Name")` will automatically create the required directory structure and files (you should provide your own "Template Name").
 
-If instead you wish to set up your template manually, create a subdirectory of the `inst/rmarkdown/templates` directory. Within this directory, you will save at least two files:
+If you wish to set up your template manually instead, create a subdirectory of the `inst/rmarkdown/templates` directory. Within this directory, you need to save at least two files:
 
-1. A file named `template.yaml` which gives the RStudio IDE basic metadata such as a human-readable name for the template. At minimum, this file should have `name` and `description` fields. 
+1. A file named `template.yaml`, which gives the RStudio IDE basic metadata such as a human-readable name for the template. At the minimum, this file should have the `name` and `description` fields, e.g.,
 
-```yaml
-name: Example Template
-description: What this template does
-```
+    ```yaml
+    name: Example Template
+    description: What this template does
+    ```
 
-You may include `create_dir: true` if you want a new directory to be created when the template is selected. This is useful if your template relies upon additional resources. For example, the **learnr** [package template](https://github.com/rstudio/learnr/blob/master/inst/rmarkdown/templates/tutorial/template.yaml) sets `create_dir: true` whereas the **flexdashboard** [package template](https://github.com/rstudio/flexdashboard/blob/master/inst/rmarkdown/templates/flex_dashboard/template.yaml) uses the default `create_dir: false`. You may attempt to open both of these templates in RStudio to notice the different user prompts.
+    You may include `create_dir: true` if you want a new directory to be created when the template is selected. This is useful if your template relies upon additional resources. For example, the [**learnr** package template](https://github.com/rstudio/learnr/blob/master/inst/rmarkdown/templates/tutorial/template.yaml) sets `create_dir: true`, whereas the [**flexdashboard** package template](https://github.com/rstudio/flexdashboard/blob/master/inst/rmarkdown/templates/flex_dashboard/template.yaml) uses the default `create_dir: false`. You may attempt to open both of these templates in RStudio to notice the different user prompts.
 
 2. An R Markdown document saved under `skeleton/skeleton.Rmd`. This may contain anything you wish to put in an R Markdown document. 
 

--- a/16-projects.Rmd
+++ b/16-projects.Rmd
@@ -267,9 +267,9 @@ The vignette output format does not have to be HTML. It can also be PDF, so you 
 
 ## R package templates
 
-In section \@ref(package-vignette), you learned how to include an R Markdown document in a package as a vignette. This is an excellent way to demonstrate the package's functionality, but it is not the only way that R Markdown documents can be used in an R package. You may also include editable R Markdown templates in your package.
+In section \@ref(package-vignette), you learned how to include an R Markdown document in a package as a vignette. This is an excellent way to demonstrate the package's functionality, but it is not the only way that R Markdown documents can be used in an R package. As a package developer, you may also include editable R Markdown templates in your package.
 
-R Markdown templates help package users interact with a package by provide boilerplate code or document structure. In fact, section \@ref(package-vignette) itself demonstrates a compelling use case. The "Package Vignette (HTML)" template is contained in the **rmarkdown** package and is easily accessible through the RStudio IDE. This template gives vignette authors a file to edit which already contains the appropriate YAML metadata for a package vignette. 
+R Markdown templates help package users interact with a package by provide boilerplate code or document structure. In fact, section \@ref(package-vignette) on package vignettes provides a compelling use case. Figure \@ref(fig:package-vignette) shows how RStudio users can use the menu `File -> New File -> R Markdown -> From Template` to retrieve the "Package Vignette (HTML)" template from the **rmarkdown** package. This template offers a file to edit which already contains the appropriate YAML metadata for a package vignette. 
 
 Templates can also include boilerplate content and showcase a package's features. For example, the **flexdashboard** package contains a sample dashboard and the **xaringan** package contains a presentation template which demonstrates many formatting options.
 

--- a/16-projects.Rmd
+++ b/16-projects.Rmd
@@ -296,7 +296,7 @@ name: Example Template
 description: What this template does
 ```
 
-You may include is `create_dir: true` if you want a new directory to be created when the template is selected. This is useful if your template relies upon additional resources. For example, the **learnr** [package template](https://github.com/rstudio/learnr/blob/master/inst/rmarkdown/templates/tutorial/template.yaml) sets `create_dir: true` whereas the **flexdashboard** [package template](https://github.com/rstudio/flexdashboard/blob/master/inst/rmarkdown/templates/flex_dashboard/template.yaml) uses the default `create_dir: false`. You may attempt to open both of these templates in RStudio to notice the differet user prompts.
+You may include `create_dir: true` if you want a new directory to be created when the template is selected. This is useful if your template relies upon additional resources. For example, the **learnr** [package template](https://github.com/rstudio/learnr/blob/master/inst/rmarkdown/templates/tutorial/template.yaml) sets `create_dir: true` whereas the **flexdashboard** [package template](https://github.com/rstudio/flexdashboard/blob/master/inst/rmarkdown/templates/flex_dashboard/template.yaml) uses the default `create_dir: false`. You may attempt to open both of these templates in RStudio to notice the different user prompts.
 
 2. An R Markdown document saved under `skeleton/skeleton.Rmd`. This may contain anything you wish to put in an R Markdown document. 
 

--- a/16-projects.Rmd
+++ b/16-projects.Rmd
@@ -267,11 +267,13 @@ The vignette output format does not have to be HTML. It can also be PDF, so you 
 
 ## R package templates
 
-In section \@ref(package-vignette), you learned how to include an R Markdown document in a package as a vignette. This is an excellent way to demonstrate the functionality of your package. However, it is not the only way that RMarkdown documents can be included in an R package. You may also include editable R Markdown templates in your package.
+In section \@ref(package-vignette), you learned how to include an R Markdown document in a package as a vignette. This is an excellent way to demonstrate the package's functionality, but it is not the only way that R Markdown documents can be used in an R package. You may also include editable R Markdown templates in your package.
 
-R Markdown templates are often included to help package users structure their document correctly. In fact, section \@ref(package-vignette) itself shows this feature in action. The "Package Vignette (HTML)" template is contained in the **rmarkdown** package and is easily accessible through the RStudio IDE. This template gives vignette authors a file to edit which already contains the appropriate YAML metadata for an R Markdown vignette. Templates can also help demonstrate package features and provide scaffolding code for users. For example, the **flexdashboard** package contains a sample dashboard template and the **xaringan** package contains a template demonstrating many formatting features. 
+R Markdown templates help package users interact with a package by provide boilerplate code or document structure. In fact, section \@ref(package-vignette) itself demonstrates a compelling use case. The "Package Vignette (HTML)" template is contained in the **rmarkdown** package and is easily accessible through the RStudio IDE. This template gives vignette authors a file to edit which already contains the appropriate YAML metadata for a package vignette. 
 
-Each R Markdown template lives in its own subdirectory of the `inst/rmarkdown/templates` directory of your package. Within this directory, you will create at least two files:
+Templates can also include boilerplate content and showcase a package's features. For example, the **flexdashboard** package contains a sample dashboard and the **xaringan** package contains a presentation template which demonstrates many formatting options.
+
+To add an R Markdown template to a package, create a subdirectory of the `inst/rmarkdown/templates` directory. Within this directory, you will save at least two files:
 
 1. A file named `template.yaml` which gives the RStudio IDE basic metadata such as a human-readable name for the template
 
@@ -283,7 +285,7 @@ name: Example Template
 
 Optionally, the `skeleton` folder may also include additional resources like style sheets or images used by your template. 
 
-As with vignettes, the **usethis** package has the helpful function `usethis::use_rmarkdown_template()` which automatically creates the required subdirectories and files.
+Similar to vignettes, the **usethis** package also has a helpful function for creating templates. Running `usethis::use_rmarkdown_template()` will automatically create the required subdirectories and files.
 
 ## Write books and long-form reports with **bookdown** {#bookdown}
 

--- a/16-projects.Rmd
+++ b/16-projects.Rmd
@@ -269,7 +269,7 @@ The vignette output format does not have to be HTML. It can also be PDF, so you 
 
 In section \@ref(package-vignette), you learned how to include an R Markdown document in a package as a vignette. This is an excellent way to demonstrate the package's functionality, but it is not the only way that R Markdown documents can be used in an R package. As a package developer, you may also include editable R Markdown templates in your package.
 
-R Markdown templates help package users interact with a package by provide boilerplate code or document structure. In fact, section \@ref(package-vignette) on package vignettes provides a compelling use case. Figure \@ref(fig:package-vignette) shows how RStudio users can use the menu `File -> New File -> R Markdown -> From Template` to retrieve the "Package Vignette (HTML)" template from the **rmarkdown** package. This template offers a file to edit which already contains the appropriate YAML metadata for a package vignette. 
+R Markdown templates help package users interact with a package by providing boilerplate code or document structure. In fact, section \@ref(package-vignette) on package vignettes provides a compelling use case. Figure \@ref(fig:package-vignette) shows how RStudio users can use the menu `File -> New File -> R Markdown -> From Template` to retrieve the "Package Vignette (HTML)" template from the **rmarkdown** package. This template offers a file to edit which already contains the appropriate YAML metadata for a package vignette. 
 
 Templates can also include boilerplate content and showcase a package's features. For example, the **flexdashboard** package contains a sample dashboard and the **xaringan** package contains a presentation template which demonstrates many formatting options.
 


### PR DESCRIPTION
This PR adds a new section to the Projects chapter, per #230 . Following the discussion of adding an R Markdown vignette, this section explain how to add an R Markdown template (for which the vignette section is actually a nice example!) 

I have a few small questions on best practices:

- I reference the Vignette section twice with `\@ref()`. Is this redundant? It felt slightly strange, but I want to avoid using terms like "the previous section" in case order would change. 
- Is there a guiding principle for what to assume the reader has already read? I repeat some of the content in this section from the previous vignette section. My goal was to make it understandable independently, but I can imagine this being frustrating to someone reading linearly