### PR TITLE
HTML Recipes (favicon, hosting)

### DIFF
--- a/07-html.Rmd
+++ b/07-html.Rmd
@@ -6,6 +6,37 @@ In this chapter, we introduce techniques to enhance your HTML output from R Mark
 
 ## Sharing HTML content on the web
 
+One advantage of the HTML output format is that HTML documents can function as static web pages. This makes it possible to host the on the internet. Sharing your work online gives it more visibility  
+
+### R-specific services
+
+RStudio PBC offers a number of services for publishing various types of content created in R Markdown to the internet. These services make it particularly easy to publish content by using the RStudio IDE or the **rsconnect** package.
+
+- [**RPubs**](https://rpubs.com/): RPubs enables free hosting of static single-file R Markdown content. It is easy to publish via the Publish button in the RStudio IDE or the `rsconnect::rpubsUpload()` function. Please see the "Getting Started" page (https://rpubs.com/about/getting-started) for more details.
+
+- [**shinyapps.io**](https://www.shinyapps.io/): Most R Markdown documents with HTML output are rendered to a static HTML file. However, if you have made an interactive document with the `runtime: shiny` option, it must be hosted on a server which can run R. shinyapps.io is an analog to RPubs which enables easy deployment of Shiny apps (by push-button in the RStudio IDE or using the `rsconnect::deployApp()` function). See the user guide (https://docs.rstudio.com/shinyapps.io/index.html) for more details. You may start for free depending on the requirements of your application. 
+
+- [**bookdown.org**](https://bookdown.org/home/about/) offers free hosting services specifically intended for books written with the **bookdown** package. Static output files of your book can be easily published using the `bookdown::publish_book()` function. This platform is based on RStudio PBC's enterprise RStudio Connect product (see below).
+
+- [**RStudio Connect**](https://rstudio.com/products/connect/) is an enterprise product which individual organizations may run on their own servers. It offers the ability to host web content in a secured environment with document-level access controls, viewership history, and more. It supports all of the different types of content R Markdown can produce (as well as `shiny` apps and `plumber` APIs.) Similar to the open-source RPubs and shinyapps.io offerings, content can be published to RStudio Connect using manual upload, the **rsconnect** package, or with Git-based deployment. 
+
+### Static website services
+
+In addition to R-specific services, you may host your HTML document on many freely available static website hosting services. These include:
+
+- [**Netlify**]()
+
+- [**GitHub Pages**]()
+
+- [**Gitlab Pages**]()
+
+- **Self hosting on a web server**
+
+Static website service:
+Netlify: Hosting service for static website stack. Will support any non shiny runtime production. Mostly use for Blogdown or pkgdown website, but can be used to publish one document also. Great resource: https://rstudio.com/resources/webinars/sharing-on-short-notice-how-to-get-your-materials-online-with-r-markdown/ . One can publish by drag and drop or using a cli tool : most often this is integrated into continuous deployment pipeline
+
+CI related hosting service (Github Pages, Gitlab Pages) : Allows to easily serve a static website from files that are included in the code repository service (Github, Gitlab). Either published by continuous deployment pipeline or by putting the website file into a specific folder in the repository or being the repository itself. (For Github page)
+Self hosting method using any web server : using apache, nginx or else, one can decide to host itself its documents or website. On its own servers or using docker container.
 
 
 ## Apply custom CSS {#html-css}

--- a/07-html.Rmd
+++ b/07-html.Rmd
@@ -297,33 +297,6 @@ For multiple files, they are first compressed to a zip file, and the zip file wi
 
 You can learn more technical details behind these functions from the help page `?xfun::embed_file` or the blog post at https://yihui.org/en/2018/07/embed-file/. Based on the same idea, the **downloadthis** package (https://github.com/fmmattioni/downloadthis) has implemented download buttons, so that users can click buttons to download files instead of links. If you prefer using buttons, you may consider using this package.
 
-## Add a custom browser icon
-
-Section \@ref(include-html) demonstrates that we can inject additional code into the HTML head, body, or footer with the `includes` option of the `html_document` format. This technique can be used to add a custom browser icon, called a favicon, to your HTML output. 
-
-Favicons are the website logos that are displayed in your browser's address bar, tab title, history, and  bookmarks. For example, if you visit the Comprehensive R Archive Network website (https://cran.r-project.org/) in Google Chrome and look at the browser tab, you will see a small R logo. On mobile devices, favicons are also used in place of an app icon for websites that are pinned to the home screen. 
-
-To add a favicon to your HTML document, add the following line of code to a custom header file (such as the file `header.html` mentioned in \@ref(include-html)):
-
-```html
-<link rel="shortcut icon" href="{path to favicon file}">
-```
-
-Recall that this file can be injected into the document `<head>` area using the YAML metadata.
-
-```yaml
-output:
-  html_document:
-    includes:
-      in_header: header.html
-```
-
-If you are making a self-contained R Markdown document (the default for the `html_document` format), the path you provide to `href` should assume the same relative path structure as you would use to reference any other asset (e.g. an image or data set). 
-
-Most small, square PNG files will work reasonably well as a favicon. Bear in mind that a typical web browser will often display the image in a 16 x 16 pixel box, so simple designs are better. 
-
-If you want to ensure that each browser or platform on which your document is viewed uses a version of your icon with optimal resolution for its specific layout, you may use a service such as https://realfavicongenerator.net/ to generate a set of favicons and a slightly more complex version of the header HTML code. This service is currently used by the **pkgdown** package's `pkgdown::build_favicon()` function to make a set of favicons out of R package logos. 
-
 ## Include the content of an existing HTML file {#include-html}
 
 With the `includes` option of the `html_document` format (or any other formats that support this option), you can include the content of an existing HTML file into the HTML output document in three possible places: the `<head>` area, the beginning of `<body>`, and the end of `</body>`.
@@ -436,6 +409,29 @@ In an `Rhtml` document, code chunks are embedded between `<!--begin.rcode` and `
 
 `r import_example('knitr.Rhtml')`
 
+## Add a custom browser icon
 
+Section \@ref(include-html) demonstrates that we can inject additional code into the HTML head, body, or footer with the `includes` option of the `html_document` format. This technique can be used to add a custom browser icon, called a favicon, to your HTML output. 
 
+Favicons are the website logos that are displayed in your browser's address bar, tab title, history, and  bookmarks. For example, if you visit the Comprehensive R Archive Network website (https://cran.r-project.org/) in Google Chrome and look at the browser tab, you will see a small R logo. On mobile devices, favicons are also used in place of an app icon for websites that are pinned to the home screen. 
 
+To add a favicon to your HTML document, add the following line of code to a custom header file (such as the file `header.html` mentioned in \@ref(include-html)):
+
+```html
+<link rel="shortcut icon" href="{path to favicon file}">
+```
+
+Recall that this file can be injected into the document `<head>` area using the YAML metadata.
+
+```yaml
+output:
+  html_document:
+    includes:
+      in_header: header.html
+```
+
+If you are making a self-contained R Markdown document (the default for the `html_document` format), the path you provide to `href` should assume the same relative path structure as you would use to reference any other asset (e.g. an image or data set). 
+
+Most small, square PNG files will work reasonably well as a favicon. Bear in mind that a typical web browser will often display the image in a 16 x 16 pixel box, so simple designs are better. 
+
+If you want to ensure that each browser or platform on which your document is viewed uses a version of your icon with optimal resolution for its specific layout, you may use a service such as https://realfavicongenerator.net/ to generate a set of favicons and a slightly more complex version of the header HTML code. This service is currently used by the **pkgdown** package's `pkgdown::build_favicon()` function to make a set of favicons out of R package logos. 

--- a/07-html.Rmd
+++ b/07-html.Rmd
@@ -4,41 +4,6 @@ Compared to LaTeX, HTML may be a little weak in typesetting for paged output, bu
 
 In this chapter, we introduce techniques to enhance your HTML output from R Markdown, including how to apply custom CSS rules, use custom HTML templates, style or fold code blocks, arrange content in tabs, and embed files on HTML pages.
 
-## Sharing HTML content on the web
-
-One advantage of the HTML output format is that HTML documents can function as static web pages. This makes it possible to host the on the internet. Sharing your work online gives it more visibility  
-
-### R-specific services
-
-RStudio PBC offers a number of services for publishing various types of content created in R Markdown to the internet. These services make it particularly easy to publish content by using the RStudio IDE or the **rsconnect** package.
-
-- [**RPubs**](https://rpubs.com/): RPubs enables free hosting of static single-file R Markdown content. It is easy to publish via the Publish button in the RStudio IDE or the `rsconnect::rpubsUpload()` function. Please see the "Getting Started" page (https://rpubs.com/about/getting-started) for more details.
-
-- [**shinyapps.io**](https://www.shinyapps.io/): Most R Markdown documents with HTML output are rendered to a static HTML file. However, if you have made an interactive document with the `runtime: shiny` option, it must be hosted on a server which can run R. shinyapps.io is an analog to RPubs which enables easy deployment of Shiny apps (by push-button in the RStudio IDE or using the `rsconnect::deployApp()` function). See the user guide (https://docs.rstudio.com/shinyapps.io/index.html) for more details. You may start for free depending on the requirements of your application. 
-
-- [**bookdown.org**](https://bookdown.org/home/about/) offers free hosting services specifically intended for books written with the **bookdown** package. Static output files of your book can be easily published using the `bookdown::publish_book()` function. This platform is based on RStudio PBC's enterprise RStudio Connect product (see below).
-
-- [**RStudio Connect**](https://rstudio.com/products/connect/) is an enterprise product which individual organizations may run on their own servers. It offers the ability to host web content in a secured environment with document-level access controls, viewership history, and more. It supports all of the different types of content R Markdown can produce (as well as `shiny` apps and `plumber` APIs.) Similar to the open-source RPubs and shinyapps.io offerings, content can be published to RStudio Connect using manual upload, the **rsconnect** package, or with Git-based deployment. 
-
-### Static website services
-
-In addition to R-specific services, you may host your HTML document on many freely available static website hosting services. These include:
-
-- [**Netlify**]()
-
-- [**GitHub Pages**]()
-
-- [**Gitlab Pages**]()
-
-- **Self hosting on a web server**
-
-Static website service:
-Netlify: Hosting service for static website stack. Will support any non shiny runtime production. Mostly use for Blogdown or pkgdown website, but can be used to publish one document also. Great resource: https://rstudio.com/resources/webinars/sharing-on-short-notice-how-to-get-your-materials-online-with-r-markdown/ . One can publish by drag and drop or using a cli tool : most often this is integrated into continuous deployment pipeline
-
-CI related hosting service (Github Pages, Gitlab Pages) : Allows to easily serve a static website from files that are included in the code repository service (Github, Gitlab). Either published by continuous deployment pipeline or by putting the website file into a specific folder in the repository or being the repository itself. (For Github page)
-Self hosting method using any web server : using apache, nginx or else, one can decide to host itself its documents or website. On its own servers or using docker container.
-
-
 ## Apply custom CSS {#html-css}
 
 We strongly recommend that you learn some CSS and JavaScript if you wish to customize the appearance of HTML documents. The [Appendix B](https://bookdown.org/yihui/blogdown/website-basics.html) of the **blogdown** book [@blogdown2017] contains short tutorials on HTML, CSS, and JavaScript.
@@ -470,3 +435,29 @@ If you are making a self-contained R Markdown document (the default for the `htm
 Most small, square PNG files will work reasonably well as a favicon. Bear in mind that a typical web browser will often display the image in a 16 x 16 pixel box, so simple designs are better. 
 
 If you want to ensure that each browser or platform on which your document is viewed uses a version of your icon with optimal resolution for its specific layout, you may use a service such as https://realfavicongenerator.net/ to generate a set of favicons and a slightly more complex version of the header HTML code. This service is currently used by the **pkgdown** package's `pkgdown::build_favicon()` function to make a set of favicons out of R package logos. 
+
+## Sharing HTML content on the web
+
+One appealing aspect of rendering R Markdown content to HTML files is that it is very easy to host these files on the internet and share them just as one shares any other website. This section briefly summarizes numerous options for sharing the HTML documents which you create. 
+
+### R-specific services
+
+RStudio PBC offers a number of services for publishing various types of content created in R Markdown to the internet. These services make it particularly easy to publish content by using the RStudio IDE or the **rsconnect** package.
+
+- [**RPubs**](https://rpubs.com/): RPubs enables free hosting of static single-file R Markdown content. It is easy to publish via the Publish button in the RStudio IDE or the `rsconnect::rpubsUpload()` function. Please see the "Getting Started" page (https://rpubs.com/about/getting-started) for more details.
+
+- [**shinyapps.io**](https://www.shinyapps.io/): Most R Markdown documents with HTML output are rendered to a static HTML file. However, if you have made an interactive document with the `runtime: shiny` option, it must be hosted on a server which can run R. shinyapps.io is an analog to RPubs which enables easy deployment of Shiny apps (by push-button in the RStudio IDE or using the `rsconnect::deployApp()` function). See the user guide (https://docs.rstudio.com/shinyapps.io/index.html) for more details. You may start for free depending on the requirements of your application. 
+
+- [**bookdown.org**](https://bookdown.org/home/about/) offers free hosting services specifically intended for books written with the **bookdown** package. Static output files of your book can be easily published using the `bookdown::publish_book()` function. This platform is based on RStudio PBC's enterprise RStudio Connect product (see below).
+
+- [**RStudio Connect**](https://rstudio.com/products/connect/) is an enterprise product which individual organizations may run on their own servers. It offers the ability to host web content in a secured environment with document-level access controls, viewership history, and more. It supports all of the different types of content R Markdown can produce (as well as `shiny` apps and `plumber` APIs.) Similar to the open-source RPubs and shinyapps.io offerings, content can be published to RStudio Connect using manual upload, the **rsconnect** package, or with Git-based deployment. 
+
+### Static website services
+
+In addition to R-specific services, you may host your HTML document on many freely available static website hosting services. These include:
+
+- [**GitHub Pages**](https://pages.github.com/) makes is particularly easy to publish HTML content straight from a GitHub repository. You may specify whether to host content from either your main branch's root, your main branch's `docs/` folder, or a specific `gh-pages` branch. You can publish new content simply by pushing new HTML files to your repository.
+
+- [**GitLab Pages**](https://docs.gitlab.com/ee/user/project/pages/) offers similar functionality to GitHub Pages for GitLab repositories. 
+
+- [**Netlify**](https://www.netlify.com/) is a platform to build and deploy static website content. It is a popular choice for web content created by the **blogdown** and **pkgdown** packages, but it could be used for other HTML content also. Compared to GitHub Pages, it offers more advanced features such as deploy previews and compatability with all major static site generators (e.g. Hugo). The deployment process is just as easy as GitHub Pages with many different options including drag-and-drop, command line, or Git integration. See the Netlify documentation (https://docs.netlify.com/) or the RStudio webinar "Sharing on Short Notice" (https://rstudio.com/resources/webinars/sharing-on-short-notice-how-to-get-your-materials-online-with-r-markdown/) for more details. 

--- a/07-html.Rmd
+++ b/07-html.Rmd
@@ -297,6 +297,33 @@ For multiple files, they are first compressed to a zip file, and the zip file wi
 
 You can learn more technical details behind these functions from the help page `?xfun::embed_file` or the blog post at https://yihui.org/en/2018/07/embed-file/. Based on the same idea, the **downloadthis** package (https://github.com/fmmattioni/downloadthis) has implemented download buttons, so that users can click buttons to download files instead of links. If you prefer using buttons, you may consider using this package.
 
+## Add a custom browser icon
+
+Section \@ref(include-html) demonstrates that we can inject additional code into the HTML head, body, or footer with the `includes` option of the `html_document` format. This technique can be used to add a custom browser icon, called a favicon, to your HTML output. 
+
+Favicons are the website logos that are displayed in your browser's address bar, tab title, history, and  bookmarks. For example, if you visit the Comprehensive R Archive Network website (https://cran.r-project.org/) in Google Chrome and look at the browser tab, you will see a small R logo. On mobile devices, favicons are also used in place of an app icon for websites that are pinned to the home screen. 
+
+To add a favicon to your HTML document, add the following line of code to a custom header file (such as the file `header.html` mentioned in \@ref(include-html)):
+
+```html
+<link rel="shortcut icon" href="{path to favicon file}">
+```
+
+Recall that this file can be injected into the document `<head>` area using the YAML metadata.
+
+```yaml
+output:
+  html_document:
+    includes:
+      in_header: header.html
+```
+
+If you are making a self-contained R Markdown document (the default for the `html_document` format), the path you provide to `href` should assume the same relative path structure as you would use to reference any other asset (e.g. an image or data set). 
+
+Most small, square PNG files will work reasonably well as a favicon. Bear in mind that a typical web browser will often display the image in a 16 x 16 pixel box, so simple designs are better. 
+
+If you want to ensure that each browser or platform on which your document is viewed uses a version of your icon with optimal resolution for its specific layout, you may use a service such as https://realfavicongenerator.net/ to generate a set of favicons and a slightly more complex version of the header HTML code. This service is currently used by the **pkgdown** package's `pkgdown::build_favicon()` function to make a set of favicons out of R package logos. 
+
 ## Include the content of an existing HTML file {#include-html}
 
 With the `includes` option of the `html_document` format (or any other formats that support this option), you can include the content of an existing HTML file into the HTML output document in three possible places: the `<head>` area, the beginning of `<body>`, and the end of `</body>`.
@@ -408,3 +435,7 @@ In Section \@ref(latex-hardcore), we mentioned that if you feel the constraint o
 In an `Rhtml` document, code chunks are embedded between `<!--begin.rcode` and `end.rcode-->`, and inline R expressions are embedded in `<!--rinline -->`. Below is a full `Rhtml` example. You can save it to a file named `test.Rhtml`, and use `knitr::knit("test.Rhtml")` to compile it. The output will be an HTML (`.html`) file. In RStudio, you can also hit the `Knit` button on the toolbar to compile the document.
 
 `r import_example('knitr.Rhtml')`
+
+
+
+

--- a/07-html.Rmd
+++ b/07-html.Rmd
@@ -4,6 +4,10 @@ Compared to LaTeX, HTML may be a little weak in typesetting for paged output, bu
 
 In this chapter, we introduce techniques to enhance your HTML output from R Markdown, including how to apply custom CSS rules, use custom HTML templates, style or fold code blocks, arrange content in tabs, and embed files on HTML pages.
 
+## Sharing HTML content on the web
+
+
+
 ## Apply custom CSS {#html-css}
 
 We strongly recommend that you learn some CSS and JavaScript if you wish to customize the appearance of HTML documents. The [Appendix B](https://bookdown.org/yihui/blogdown/website-basics.html) of the **blogdown** book [@blogdown2017] contains short tutorials on HTML, CSS, and JavaScript.

--- a/16-projects.Rmd
+++ b/16-projects.Rmd
@@ -265,6 +265,26 @@ Note that you need to change the vignette title in both the `title` field and th
 
 The vignette output format does not have to be HTML. It can also be PDF, so you can use `output: pdf_document`, too. Any other output formats that create HTML or PDF are also okay, such as `beamer_presentation` and `tufte::tufte_html`. However, currently R only recognizes HTML and PDF vignettes.
 
+## R package templates
+
+In section \@ref(package-vignette), you learned how to include an R Markdown document in a package as a vignette. This is an excellent way to demonstrate the functionality of your package. However, it is not the only way that RMarkdown documents can be included in an R package. You may also include editable R Markdown templates in your package.
+
+R Markdown templates are often included to help package users structure their document correctly. In fact, section \@ref(package-vignette) itself shows this feature in action. The "Package Vignette (HTML)" template is contained in the **rmarkdown** package and is easily accessible through the RStudio IDE. This template gives vignette authors a file to edit which already contains the appropriate YAML metadata for an R Markdown vignette. Templates can also help demonstrate package features and provide scaffolding code for users. For example, the **flexdashboard** package contains a sample dashboard template and the **xaringan** package contains a template demonstrating many formatting features. 
+
+Each R Markdown template lives in its own subdirectory of the `inst/rmarkdown/templates` directory of your package. Within this directory, you will create at least two files:
+
+1. A file named `template.yaml` which gives the RStudio IDE basic metadata such as a human-readable name for the template
+
+```yaml
+name: Example Template
+```
+
+2. An R Markdown document saved under `skeleton/skeleton.Rmd` which contains the template. This may contain anything you wish to put in an R Markdown document. 
+
+Optionally, the `skeleton` folder may also include additional resources like style sheets or images used by your template. 
+
+As with vignettes, the **usethis** package has the helpful function `usethis::use_rmarkdown_template()` which automatically creates the required subdirectories and files.
+
 ## Write books and long-form reports with **bookdown** {#bookdown}
 
 The **bookdown** package [@R-bookdown] is designed for creating long-form documents with multiple R Markdown documents. For example, if you want to write a book, you can put each chapter in its own Rmd file.

--- a/16-projects.Rmd
+++ b/16-projects.Rmd
@@ -267,9 +267,9 @@ The vignette output format does not have to be HTML. It can also be PDF, so you 
 
 ## R package templates
 
-In section \@ref(package-vignette), you learned how to include an R Markdown document in a package as a vignette. This is an excellent way to demonstrate the package's functionality, but it is not the only way that R Markdown documents can be used in an R package. You may also include editable R Markdown templates in your package.
+In section \@ref(package-vignette), you learned how to include an R Markdown document in a package as a vignette. This is an excellent way to demonstrate the package's functionality, but it is not the only way that R Markdown documents can be used in an R package. As a package developer, you may also include editable R Markdown templates in your package.
 
-R Markdown templates help package users interact with a package by provide boilerplate code or document structure. In fact, section \@ref(package-vignette) itself demonstrates a compelling use case. The "Package Vignette (HTML)" template is contained in the **rmarkdown** package and is easily accessible through the RStudio IDE. This template gives vignette authors a file to edit which already contains the appropriate YAML metadata for a package vignette. 
+R Markdown templates help package users interact with a package by provide boilerplate code or document structure. In fact, section \@ref(package-vignette) on package vignettes provides a compelling use case. Figure \@ref(fig:package-vignette) shows how RStudio users can use the menu `File -> New File -> R Markdown -> From Template` to retrieve the "Package Vignette (HTML)" template from the **rmarkdown** package. This template offers a file to edit which already contains the appropriate YAML metadata for a package vignette. 
 
 Templates can also include boilerplate content and showcase a package's features. For example, the **flexdashboard** package contains a sample dashboard and the **xaringan** package contains a presentation template which demonstrates many formatting options.
 

--- a/16-projects.Rmd
+++ b/16-projects.Rmd
@@ -267,11 +267,13 @@ The vignette output format does not have to be HTML. It can also be PDF, so you 
 
 ## R package templates
 
-In section \@ref(package-vignette), you learned how to include an R Markdown document in a package as a vignette. This is an excellent way to demonstrate the functionality of your package. However, it is not the only way that RMarkdown documents can be included in an R package. You may also include editable R Markdown templates in your package.
+In section \@ref(package-vignette), you learned how to include an R Markdown document in a package as a vignette. This is an excellent way to demonstrate the package's functionality, but it is not the only way that R Markdown documents can be used in an R package. You may also include editable R Markdown templates in your package.
 
-R Markdown templates are often included to help package users structure their document correctly. In fact, section \@ref(package-vignette) itself shows this feature in action. The "Package Vignette (HTML)" template is contained in the **rmarkdown** package and is easily accessible through the RStudio IDE. This template gives vignette authors a file to edit which already contains the appropriate YAML metadata for an R Markdown vignette. Templates can also help demonstrate package features and provide scaffolding code for users. For example, the **flexdashboard** package contains a sample dashboard template and the **xaringan** package contains a template demonstrating many formatting features. 
+R Markdown templates help package users interact with a package by provide boilerplate code or document structure. In fact, section \@ref(package-vignette) itself demonstrates a compelling use case. The "Package Vignette (HTML)" template is contained in the **rmarkdown** package and is easily accessible through the RStudio IDE. This template gives vignette authors a file to edit which already contains the appropriate YAML metadata for a package vignette. 
 
-Each R Markdown template lives in its own subdirectory of the `inst/rmarkdown/templates` directory of your package. Within this directory, you will create at least two files:
+Templates can also include boilerplate content and showcase a package's features. For example, the **flexdashboard** package contains a sample dashboard and the **xaringan** package contains a presentation template which demonstrates many formatting options.
+
+To add an R Markdown template to a package, create a subdirectory of the `inst/rmarkdown/templates` directory. Within this directory, you will save at least two files:
 
 1. A file named `template.yaml` which gives the RStudio IDE basic metadata such as a human-readable name for the template
 
@@ -283,7 +285,7 @@ name: Example Template
 
 Optionally, the `skeleton` folder may also include additional resources like style sheets or images used by your template. 
 
-As with vignettes, the **usethis** package has the helpful function `usethis::use_rmarkdown_template()` which automatically creates the required subdirectories and files.
+Similar to vignettes, the **usethis** package also has a helpful function for creating templates. Running `usethis::use_rmarkdown_template()` will automatically create the required subdirectories and files.
 
 ## Write books and long-form reports with **bookdown** {#bookdown}
 


### PR DESCRIPTION
This PR consists of two updates the the HTML output chapter.

## Favicon recipe ( closes #220 )

Provides basic instructions for adding a favicon to an RMarkdown website with the `includes:` argument. I tried to keep this part simple and short by showing the basic recipe and linking to outside web dev resources for more information on best practices or levels of complexity which are less useful for traditional RMarkdown usage.

## Hosting options ( closes #232 )

I followed @cderv 's outline in the issue fairly closely and mostly provided a list of common tools. I tried to avoid discussions of features that might change in the future. I have also linked to @yihui 's blog post about reasons to prefer Netlify over GitHub Pages. I hope that is alright! If so, is this something I should make a citation for? I tried to find other examples of blog post references to see how they were handled, but I didn't find any.  