### PR TITLE
Chapter 10 Proofreading

### DIFF
--- a/12-output-hooks.Rmd
+++ b/12-output-hooks.Rmd
@@ -52,7 +52,7 @@ knitr::knit_hooks$get('output')
 
 Unless you are truly interested in making contributions to the **knitr** package, we do not recommend that you read the source code of these built-in hooks. If you are interested, this code can be found in the scripts named in the form `hooks-*.R` at https://github.com/yihui/knitr/tree/master/R (e.g., `hooks-md.R` contains hooks for R Markdown documents). As a **knitr** user, it usually suffices if you know how to create custom output hooks by taking advantage of the built-in hooks. You will learn that in several examples in this chapter, and we show the basic idea below.
 
-A custom output hook is registered through the `set()` method on `knit_hooks`. Because this method will override the existing default hook, we recommend that you save a copy of existing hook, process the output elements in your own way, and pass the results to the default hook. The usual syntax is:
+A custom output hook is registered through the `set()` method of `knit_hooks`. Because this method will override the existing default hook, we recommend that you save a copy of existing hook, process the output elements in your own way, and pass the results to the default hook. The usual syntax is:
 
 ```{r, eval=FALSE}
 # using local() is optional here (we just want to avoid creating unnecessary global variables like `hook_old`)

--- a/12-output-hooks.Rmd
+++ b/12-output-hooks.Rmd
@@ -163,7 +163,7 @@ The main trick in the above example is to determine the number of spaces needed 
 knitr:::v_spaces(c(1, 3, 6, 0))
 ```
 
-The method introduced in Section \@ref(number-lines) may be the actual way in which you want to add line numbers to source code. The syntax is cleaner, and it works both source code and text output blocks. The above `source` hook trick mainly aims to show you one possibility of manipulating the source code with a custom function.
+The method introduced in Section \@ref(number-lines) may be the actual way in which you want to add line numbers to source code. The syntax is cleaner, and it works for both source code and text output blocks. The above `source` hook trick mainly aims to show you one possibility of manipulating the source code with a custom function.
 
 ## Scrollable text output {#hook-scroll}
 

--- a/12-output-hooks.Rmd
+++ b/12-output-hooks.Rmd
@@ -1,6 +1,6 @@
 # Output Hooks (\*) {#output-hooks}
 
-With the **knitr** package, you have control over every piece of output from your code chunks, such as source code, text output, messages, and plots. The control is achieved through "output hooks", which are a series of functions that take a piece of output as the input (typically a character vector), and return a character vector to be written to the output document. This may not be easy to understand for now, but hopefully you can see the idea more clearly with a small example below explaining how the output of a simple code chunk is rendered through **knitr**'s output hooks.
+With the **knitr** package, you have control over every piece of output from your code chunks, such as source code, text output, messages, and plots. The control is achieved through "output hooks". Output hooks are a series of functions that take a piece of output as the input (typically a character vector), and return a character vector to be written to the output document. This may not be easy to understand for now, but hopefully you can see the idea more clearly with a small example below explaining how the output of a simple code chunk is rendered through **knitr**'s output hooks.
 
 Consider this code chunk with one line of code:
 
@@ -20,7 +20,7 @@ function(x, options) {
 }
 ```
 
-Similar, the text output is processed by the `output` hook that looks like this function:
+Similarly, the text output is processed by the `output` hook that looks like this function:
 
 ```{r, eval=FALSE}
 function(x, options) {

--- a/12-output-hooks.Rmd
+++ b/12-output-hooks.Rmd
@@ -92,7 +92,7 @@ Output hooks give you the ultimate control over every single piece of your chunk
 
 ## Redact source code {#hook-hide}
 
-Sometimes we may not want to fully display our source code in the report. For example, you may have a password in a certain line of code. We mentioned in Section \@ref(hide-one) that you can use the chunk option `eval` to select which expressions in the R code to display (e.g., show the second expression via `echo = 2`). In this section, we provide a more flexible method that does not require you to specify the indices of expressions.
+Sometimes we may not want to fully display our source code in the report. For example, you may have a password in a certain line of code. We mentioned in Section \@ref(hide-one) that you can use the chunk option `echo` to select which expressions in the R code to display (e.g., show the second expression via `echo = 2`). In this section, we provide a more flexible method that does not require you to specify the indices of expressions.
 
 The basic idea is that you add a special comment to the code (e.g., `# SECRET!!`). When this comment is detected in a line of code, you omit that line. Below is a full example using the `source` hook:
 

--- a/12-output-hooks.Rmd
+++ b/12-output-hooks.Rmd
@@ -50,7 +50,7 @@ knitr::knit_hooks$get('output')
 # or knitr::knit_hooks$get(c('source', 'output'))
 ```
 
-Unless you are truly interested in making contributions to the **knitr** package, we do not recommend that you read the source code of these built-in hooks, which can be found in the scripts named in the form `hooks-*.R` at https://github.com/yihui/knitr/tree/master/R (e.g., `hooks-md.R` contains hooks for R Markdown documents). As a **knitr** user, it usually suffices if you know how to create custom output hooks by taking advantage of the built-in hooks. You will learn that in several examples in this chapter, and we show the basic idea below.
+Unless you are truly interested in making contributions to the **knitr** package, we do not recommend that you read the source code of these built-in hooks. If you are interested, this code can be found in the scripts named in the form `hooks-*.R` at https://github.com/yihui/knitr/tree/master/R (e.g., `hooks-md.R` contains hooks for R Markdown documents). As a **knitr** user, it usually suffices if you know how to create custom output hooks by taking advantage of the built-in hooks. You will learn that in several examples in this chapter, and we show the basic idea below.
 
 A custom output hook is registered through the `set()` method on `knit_hooks`. Because this method will override the existing default hook, we recommend that you save a copy of existing hook, process the output elements in your own way, and pass the results to the default hook. The usual syntax is:
 


### PR DESCRIPTION
This PR contains a handful of small changes for clarity/typos. I detailed each change in the commit message.

Additionally, I have a few issues I want to highlight for this chapter:

- In Section 10.2.2, the `strikeout = TRUE` option is not rendering in the PDF output, but it does work in the HTML output. I tried to dig in to why this is, and this is what I learned (all using the latest CRAN version of `kableExtra`).

  + This is not just true in `bookdown`, but the same thing happens when I copy that code chunk to a stand-alone Rmd and run it with `output: html_document` (which works) and `output: pdf_document` (which doesn't)
  + `strikeout` clearly can and should work in PDF, as indicated in [this GitHub issue](https://github.com/haozhu233/kableExtra/issues/99) and demonstrated in the package vignette ([output](https://cran.r-project.org/web/packages/kableExtra/vignettes/awesome_table_in_pdf.pdf) with example on p.10 and [source](https://github.com/haozhu233/kableExtra/blob/master/vignettes/awesome_table_in_pdf.Rmd))
  + The [LaTeX implementation](https://github.com/haozhu233/kableExtra/blob/9059e4bb189122fa30b456f5d2d6ca4b99f471bb/R/column_spec.R#L293) of the argument uses `sout` which is from the `ulem` LaTeX package
  + I was hopeful that declaring the LaTeX package dependency in the YAML header would work, but using either `header-includes` or `extra_dependencies` threw the error `LaTeX Error: Option clash for package ulem.` 
  + I'll admit I am quite a novice at LaTeX, so I thought I would check if any of this makes it obvious to you what is going on. Otherwise, I am happy to keep trying to debug. 

- When I added the references, I wasn't quite sure what to do with all the links in 10.3. Since the packages are not discussed in detail, these seemed potentially useful and like their purpose was greater than what the references replaced. However, currently there is a mix of references to GitHub and CRAN, although all the packages are on CRAN, and the section is very heavy on links relative to the rest of the book. Please let me know if you think I should strip them out.

- Currently, there's a completely blank page at the end of the chapter. We can check back on this after the final copy edits are in.