### PR TITLE
Small phrasing changes to improve formatting

### DIFF
--- a/04-content.Rmd
+++ b/04-content.Rmd
@@ -687,7 +687,7 @@ You can also filter code chunks using the arguments of `knitr::all_labels()`. Fo
 
 \index{Pandoc!Lua filter|see  {Lua filter}}
 
-Technically, this section may be a little advanced, but once you learn the Pandoc abstract syntax tree (AST), you will have the power of manipulating any Markdown elements with the programming language called Lua.
+Technically, this section may be a little advanced, but once you learn the how your R Markdown content is translated into the Pandoc abstract syntax tree (AST), you will have the power of manipulating any Markdown elements with the programming language called Lua.
 
 Basically, when Pandoc reads a Markdown file, the content will be parsed into an AST. Pandoc allows you to modify this AST with Lua scripts\index{Lua filter}. We use the following simple Markdown file (named `ast.md`) to show what the AST means:
 
@@ -697,21 +697,21 @@ Basically, when Pandoc reads a Markdown file, the content will be parsed into an
 Hello world!
 ```
 
-The file contains a header and a paragraph. It may be easier for R users to understand the AST if we convert the file to the JSON format:
+This file contains a header and a paragraph. After Pandoc parses this content, it may be easier for R users to understand the resulting AST if we convert the file to the JSON format:
 
 ```{sh}
 pandoc -f markdown -t json -o ast.json ast.md
 ```
 
-Then read the JSON file into R, and print out the data structure:
+Then read the JSON file into R, and print out the data structure. 
+
+When you do this, you will see that the Markdown content is represented in a recursive list. The label `t` stands for "type," and `c` stands for "content." Take the header for example. Its type is "Header", and its content has three sub-elements: the header level (`2`), the attributes (e.g., the ID is `section-one`), and the text content.
 
 ```{r, comment='', tidy=FALSE}
 xfun:::tree(
   jsonlite::fromJSON('ast.json', simplifyVector = FALSE)
 )
 ```
-
-You can see that the Markdown content is represented in a recursive list. The label `t` stands for "type," and `c` stands for "content." Take the header for example. Its type is "Header", and its content has three sub-elements: the header level (`2`), the attributes (e.g., the ID is `section-one`), and the text content.
 
 After you are aware of the AST, you can modify it with the Lua programming language. Pandoc has a built-in Lua interpreter, so you do not need to install additional tools. The Lua scripts are called "Lua filters" for Pandoc. Next we give a quick example of raising the levels of headers by one, e.g., convert level 3 headers to level 2 headers. This may be useful when the top-level headers of your document are level 2 headers, but you want to start with level 1 headers instead.
 

--- a/04-content.Rmd
+++ b/04-content.Rmd
@@ -687,7 +687,7 @@ You can also filter code chunks using the arguments of `knitr::all_labels()`. Fo
 
 \index{Pandoc!Lua filter|see  {Lua filter}}
 
-Technically, this section may be a little advanced, but once you learn the how your R Markdown content is translated into the Pandoc abstract syntax tree (AST), you will have the power of manipulating any Markdown elements with the programming language called Lua.
+Technically, this section may be a little advanced, but once you learn how your Markdown content is translated into the Pandoc abstract syntax tree (AST), you will have the power of manipulating any Markdown elements with the programming language called Lua.
 
 Basically, when Pandoc reads a Markdown file, the content will be parsed into an AST. Pandoc allows you to modify this AST with Lua scripts\index{Lua filter}. We use the following simple Markdown file (named `ast.md`) to show what the AST means:
 
@@ -705,7 +705,7 @@ pandoc -f markdown -t json -o ast.json ast.md
 
 Then read the JSON file into R, and print out the data structure. 
 
-When you do this, you will see that the Markdown content is represented in a recursive list. The label `t` stands for "type," and `c` stands for "content." Take the header for example. Its type is "Header", and its content has three sub-elements: the header level (`2`), the attributes (e.g., the ID is `section-one`), and the text content.
+When you do this, you will see that the Markdown content is represented in a recursive list. Its structure is printed below. The label `t` stands for "type," and `c` stands for "content." Take the header for example. Its type is "Header", and its content has three sub-elements: the header level (`2`), the attributes (e.g., the ID is `section-one`), and the text content.
 
 ```{r, comment='', tidy=FALSE}
 xfun:::tree(

--- a/05-formatting.Rmd
+++ b/05-formatting.Rmd
@@ -234,17 +234,20 @@ Why four backticks? That is because you have to use at least N+1 backticks to wr
 
 ### Show a verbatim inline expression
 
-There are multiple ways to show a verbatim inline expression. The first way is to break the inline expression after `` `r``, e.g.,
+There are multiple ways to show a verbatim inline expression. 
+
+The first way is to break the inline expression after `` `r``, e.g.,
 
 ```md
 This will show a verbatim inline R expression `` `r
 1+1` `` in the output.
 ```
-
-The trick works for two reasons: (1) a single line break is often the same as a space to Markdown parsers (by comparison, two consecutive line breaks means starting a new paragraph); (2) **knitr** requires a space after `` `r `` to parse it; if the space is missing, it will not be treated as an inline expression. In the output document, you should see:
+In the output document, you should see:
 
 > This will show a verbatim inline R expression `` `r
 1+1` `` in the output.
+
+The trick works for two reasons: (1) a single line break is often the same as a space to Markdown parsers (by comparison, two consecutive line breaks means starting a new paragraph); (2) **knitr** requires a space after `` `r `` to parse it; if the space is missing, it will not be treated as an inline expression.
 
 Another way to show a verbatim inline R expression is to wrap the R code in `knitr::inline_expr()`, e.g.,
 

--- a/16-projects.Rmd
+++ b/16-projects.Rmd
@@ -339,9 +339,11 @@ For more details on building custom R Markdown templates, please refer to the [R
 
 ## Write books and long-form reports with **bookdown** {#bookdown}
 
-The **bookdown** package [@R-bookdown]\index{R package!bookdown} is designed for creating long-form documents\index{book} with multiple R Markdown documents. For example, if you want to write a book, you can put each chapter in its own Rmd file.
+The **bookdown** package [@R-bookdown]\index{R package!bookdown} is designed for creating long-form documents\index{book} which are composed of multiple R Markdown documents. For example, if you want to write a book like this one, you can write each chapter in its own Rmd file and use **bookdown** to compile them.
 
-For RStudio users, the easiest way to get started is to create a **bookdown** project\index{RStudio!bookdown project} from `File -> New Project -> New Directory -> Book Project using bookdown`, as you can see from Figure \@ref(fig:bookdown-project). If you do not use RStudio, you may call the function `bookdown:::bookdown_skeleton('your-book-dir')`.
+For RStudio users, the easiest way to get started is to create a **bookdown** project\index{RStudio!bookdown project} with the IDE by selecting `File -> New Project -> New Directory -> Book Project using bookdown`. You can preview this approach in Figure \@ref(fig:bookdown-project).
+
+If you do not use RStudio or if you prefer to work from the console, you may produce the same result by calling the function `bookdown:::bookdown_skeleton('your-book-dir')`.
 
 ```{r, bookdown-project, echo=FALSE, fig.cap='Create a bookdown project in RStudio.'}
 knitr::include_graphics('images/bookdown-project.png', dpi = NA)

--- a/16-projects.Rmd
+++ b/16-projects.Rmd
@@ -339,7 +339,7 @@ For more details on building custom R Markdown templates, please refer to the [R
 
 ## Write books and long-form reports with **bookdown** {#bookdown}
 
-The **bookdown** package [@R-bookdown]\index{R package!bookdown} is designed for creating long-form documents\index{book} which are composed of multiple R Markdown documents. For example, if you want to write a book like this one, you can write each chapter in its own Rmd file and use **bookdown** to compile them.
+The **bookdown** package [@R-bookdown]\index{R package!bookdown} is designed for creating long-form documents\index{book} that are composed of multiple R Markdown documents. For example, if you want to write a book like this one, you can write each chapter in its own Rmd file and use **bookdown** to compile them.
 
 For RStudio users, the easiest way to get started is to create a **bookdown** project\index{RStudio!bookdown project} with the IDE by selecting `File -> New Project -> New Directory -> Book Project using bookdown`. You can preview this approach in Figure \@ref(fig:bookdown-project).
 


### PR DESCRIPTION
This PR resolves formatting issues to close #210.

Ultimately, four issues were found highlighted for me to look at in #210. This is how I resolved them:

1. Ch4 AST diagram

![image](https://user-images.githubusercontent.com/19798371/90079737-5a06f300-dcce-11ea-839a-bde05e458d03.png)

2. Ch5 Bar to close off example spilling over

![image](https://user-images.githubusercontent.com/19798371/90079788-79058500-dcce-11ea-96ca-76922df6b532.png)

3. python language engine code chunk split across pages 

This one was resolved with the other changes by chance. In the current version of the PDF that @yihui produced, it is no longer an issue (page 257). This was extremely lucky because this is the chapter I have trouble knitting. 😆

4. Ch16 bookdown section

![image](https://user-images.githubusercontent.com/19798371/90079698-3a6fca80-dcce-11ea-9026-1a4ff6167410.png)

For the three chapters I changed (4, 5, and 16), I scrolled through the remained of the chapter to make sure that these fixed didn't cause other formatting errors later on. 