### PR TITLE
Fix Travis CI bug (disallow asy chunk)

### DIFF
--- a/15-languages.Rmd
+++ b/15-languages.Rmd
@@ -277,7 +277,8 @@ The `stata` engine in **knitr** is quite limited. Doug Hemken has substantially 
 eval_asy <- function() {
 	check_not_windows <- Sys.info()['sysname'] != 'Windows'
 	check_has_asymptote <- nzchar(Sys.which("asy"))
-	eval_asy <- check_not_windows & check_has_asymptote
+	check_not_ci <- is.na(Sys.getenv('CI', NA))
+	eval_asy <- check_not_windows & check_has_asymptote & check_not_ci
 	if (!eval_asy) 
 		warning("System set-up not compatible with Asymptote, so chunks with asy engine will be skipped.")
 	eval_asy


### PR DESCRIPTION
This PR adds back the check for CI when deciding whether to evaluate the `asy` chunk. I accidentally deleted this when adding the additional conditions regarding Windows and Asymptote installation.

I apologize for doing this in two PRs. I thought the test build had finished before I merged, but I apparently was mistaken. This PR fixes that issue. 