### PR TITLE
Use LaTeX font packages instead of system fonts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ addons:
     - libpoppler-cpp-dev
     - libmagick++-dev
     - asymptote
+    - libgit2-dev
+    - libharfbuzz-dev
+    - libfribidi-dev
+    - libgit2-dev
+    - libglu1-mesa-dev
 
 services:
   - xvfb

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,4 +3,4 @@ Type: Book
 Title: Does not matter.
 Version: 0.0.1
 Imports: bookdown, DiagrammeR, blogdown, webshot, fs, here, sass
-Remotes: yihui/xfun, yihui/knitr
+Remotes: yihui/xfun, yihui/knitr, rstudio/bookdown

--- a/SETUP.md
+++ b/SETUP.md
@@ -20,12 +20,6 @@ The TinyTex LaTeX distribution is required to build the book. This is installed 
 
 Additionally, the `pgf`, `preview`, and `xcolor` packages are required to build [11-chunk-options.Rmd](https://github.com/yihui/rmarkdown-cookbook/blob/master/11-chunk-options.Rmd) and will be installed as needed when running that chapter. 
 
-### Fonts
-
-To make the "Build All" button (described below) work, you will need the [Alegraya font family](https://fonts.google.com/specimen/Alegreya) from Google Fonts. For Windows 10, you may follow the instructions [here](https://winaero.com/how-to-install-and-use-google-fonts-in-windows-10/) to download (or find similar instructions for your OS).
-
-Importantly, on Windows, be sure to install the font to your system instead of simply your account.
-
 ### Other System Dependencies
 
 For Windows users, the section of the book on the [Asymptote language engine](https://bookdown.org/yihui/rmarkdown-cookbook/eng-asy.html) does not build properly so it will be skipped. For users with other operating systems, this section will be skipped if Asymptote is not installed on your computer. If they wish to build this section, they must download and install the [Asymptote software](https://asymptote.sourceforge.io/) from its website. After you install it, you may confirm that it is on your system's path by running the terminal command `where asy` or `Sys.which("asy")` from within R.

--- a/index.Rmd
+++ b/index.Rmd
@@ -14,8 +14,6 @@ graphics: yes
 lot: yes
 lof: yes
 fontsize: 11pt
-monofont: "Source Code Pro"
-monofontoptions: "Scale=0.8"
 site: bookdown::bookdown_site
 github-repo: yihui/rmarkdown-cookbook
 url: 'https\://bookdown.org/yihui/rmarkdown-cookbook/'

--- a/latex/preamble.tex
+++ b/latex/preamble.tex
@@ -2,7 +2,8 @@
 \usepackage{longtable}
 \usepackage[bf,singlelinecheck=off]{caption}
 
-\setmainfont[UprightFeatures={SmallCapsFont=AlegreyaSC-Regular}]{Alegreya}
+\usepackage{Alegreya}
+\usepackage[scale=.8]{sourcecodepro}
 
 \usepackage{framed,color}
 \definecolor{shadecolor}{RGB}{248,248,248}


### PR DESCRIPTION
because LaTeX packages could be automatically installed if missing.

This was borrowed from: https://github.com/rstudio/bookdown/commit/5cf9766934ff4d979bc0c9a656b390160390ac84