### PR TITLE
Update trackdown now on cran

### DIFF
--- a/17-workflow.Rmd
+++ b/17-workflow.Rmd
@@ -237,7 +237,17 @@ You may refer to the help page `?rmarkdown::render` to find out more ideas on ho
 
 The **trackdown** package\index{R package!trackdown} [@R-trackdown] offers a simple solution for collaborative writing and editing of R Markdown (or Sweave) documents. Based on the **googledrive** package\index{R package!googledrive} [@R-googledrive],  **trackdown** allows to upload the local `.Rmd` (or `.Rnw`) file as a plain-text file to Google Drive. By taking advantage of the easily readable Markdown (or LaTeX) syntax and the well-known online interface offered by Google Docs, collaborators can easily contribute to the writing and editing process. After integrating all authors’ contributions, the final document can be downloaded and rendered locally.
 
-Currently, **trackdown** is available only on GitHub at https://github.com/ekothe/trackdown. The package documentation is available at https://ekothe.github.io/trackdown/.
+You can install **trackdown** from CRAN, or you may try the development version on GitHub (https://github.com/claudiozandonella/trackdown):
+```{r, echo=TRUE, eval=FALSE}
+# install from CRAN
+install.packages("trackdown")
+
+# install the development version
+remotes::install_github("claudiozandonella/trackdown",
+                        build_vignettes = TRUE)
+```
+
+The package documentation is available at https://claudiozandonella.github.io/trackdown/.
 
 ### The trackdown Workflow
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -82,6 +82,4 @@ Imports:
     ztable
 Suggests:
     rsconnect
-Remotes:
-    github::ekothe/trackdown
 Encoding: UTF-8

--- a/renv.lock
+++ b/renv.lock
@@ -313,7 +313,7 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "e3ae5d68dea0c55a12ea12a9fda02e61"
-      },
+    },
     "clipr": {
       "Package": "clipr",
       "Version": "0.7.1",
@@ -589,7 +589,7 @@
       "Package": "gargle",
       "Version": "1.2.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "9d234e6a87a6f8181792de6dc4a00e39"
     },
     "gdtools": {
@@ -713,7 +713,7 @@
       "Package": "googledrive",
       "Version": "2.0.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "c3a25adbbfbb03f12e6f88c5fb1f3024"
     },
     "govdown": {
@@ -1612,7 +1612,7 @@
       "Package": "trackdown",
       "Version": "1.0.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Hash": "9dd20b7663c8781810b8507e5a6e91de"
     },
     "tufte": {

--- a/renv.lock
+++ b/renv.lock
@@ -309,11 +309,11 @@
     },
     "cli": {
       "Package": "cli",
-      "Version": "2.5.0",
+      "Version": "3.0.1",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "a94ba44cee3ea571e813721e64184172"
-    },
+      "Hash": "e3ae5d68dea0c55a12ea12a9fda02e61"
+      },
     "clipr": {
       "Package": "clipr",
       "Version": "0.7.1",
@@ -587,10 +587,10 @@
     },
     "gargle": {
       "Package": "gargle",
-      "Version": "1.1.0",
+      "Version": "1.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "bc3bc77ea458de0a6efe94e8e7e9c641"
+      "Repository": "CRAN",
+      "Hash": "9d234e6a87a6f8181792de6dc4a00e39"
     },
     "gdtools": {
       "Package": "gdtools",
@@ -711,10 +711,10 @@
     },
     "googledrive": {
       "Package": "googledrive",
-      "Version": "1.0.1",
+      "Version": "2.0.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "79ba5d18133290a69b7c135dc3dfef1a"
+      "Repository": "CRAN",
+      "Hash": "c3a25adbbfbb03f12e6f88c5fb1f3024"
     },
     "govdown": {
       "Package": "govdown",
@@ -1610,15 +1610,10 @@
     },
     "trackdown": {
       "Package": "trackdown",
-      "Version": "0.1.0",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteRepo": "trackdown",
-      "RemoteUsername": "ekothe",
-      "RemoteRef": "HEAD",
-      "RemoteSha": "6841b69e8f9559dab9bc6544e0c629b78df64442",
-      "Hash": "5ee1bbe7cadf782236922aca377e3220"
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "9dd20b7663c8781810b8507e5a6e91de"
     },
     "tufte": {
       "Package": "tufte",


### PR DESCRIPTION
Hi  @cderv,

Sorry for the time it took me to send this PR to update the old PR (#348) but it was a really busy month.

Now, the `trackdown` package is on CRAN ([link](https://cran.r-project.org/web/packages/trackdown/index.html)).  I have updated the information to install the package.
Note that I had to update the version of other packages as well because they are `trackdown` dependencies. In particular,

- cli 3.0
- gargle 1.2
- googledrive 2.0


Moreover, regarding the issue on `write_bib()` (knitr/issues/2028), the url is still missing from the reference because:

- although the package is now available on CRAN, the package is actually installed from the RSPM repository using `install.packages()`. This happens automatically probably for some default settings.  As a consequence, the following code is not evaluated

https://github.com/yihui/knitr/blob/d65b9239804163b693cbfa4b774980f3b7d1fecd/R/citation.R#L75-L80

- if I update `knitr` to the development version, the code below will process the first url but the url is still set in `note = ` and not in `url =` (as you already pointed out [link](https://github.com/yihui/knitr/issues/2028#issuecomment-883259576)). The note field is not printed in the reference.

https://github.com/yihui/knitr/blob/d65b9239804163b693cbfa4b774980f3b7d1fecd/R/citation.R#L102-L105

In the PR I did not updated `knitr` to the development version to avoid installing through  GitHub. Let me know if you prefer I update it.

Thanks for your work!